### PR TITLE
Update selection background color

### DIFF
--- a/themes/dark-color-theme.json
+++ b/themes/dark-color-theme.json
@@ -29,7 +29,7 @@
 		"progressBar.background": "#047aa6",
 		"editor.background": "#002b36",
 		"editorWidget.background": "#00212b",
-		"editor.selectionBackground": "#073642",
+		"editor.selectionBackground": "#586e75",
 		"editor.selectionHighlightBackground": "#005a6faa",
 		"editorHoverWidget.background": "#004052",
 		"editor.lineHighlightBackground": "#073642",

--- a/themes/light-color-theme.json
+++ b/themes/light-color-theme.json
@@ -22,7 +22,7 @@
 		"progressBar.background": "#b58900",
 		"editor.background": "#fdf6e3",
 		"editorWidget.background": "#eee8d5",
-		"editor.selectionBackground": "#eee8d5",
+		"editor.selectionBackground": "#93a1a1",
 		"editorHoverWidget.background": "#ccc4b0",
 		"editor.lineHighlightBackground": "#eee8d5",
 		"editorCursor.foreground": "#657b83",


### PR DESCRIPTION
The `selectionBackground` matches the `lineHighlightBackground`, making it difficult to see what is selected when the cursor is in the same line as the selection. This is especially relevant when working with VIM plugins in visual mode.

This PR updates the colours using the [VIM](https://github.com/altercation/vim-colors-solarized/blob/master/colors/solarized.vim#L247) colour scheme as a reference.

I'm not convinced by the light mode selection colour, but the original is equally ugly so I'm happy to settle for it. But let me know what you think!

Here are a couple of screenshots of how it looks:

**Dark**:
![dark](https://user-images.githubusercontent.com/3746468/91881811-00189e00-ec7a-11ea-9568-1466c533552c.png)

**Light**:
![light](https://user-images.githubusercontent.com/3746468/91881838-060e7f00-ec7a-11ea-83d2-82fb89391e06.png)
